### PR TITLE
Handle Invalid Dates

### DIFF
--- a/src/components/Education/EducationTitle.js
+++ b/src/components/Education/EducationTitle.js
@@ -10,7 +10,7 @@
 
 import { Box, makeStyles, Typography } from "@material-ui/core";
 import React from "react";
-import { parseDateView } from "../../utils/Helpers";
+import { parseDateView, parseEndYear } from "../../utils/Helpers";
 import { TitleBox } from "../common/TitleBox";
 
 const useStyles = makeStyles((theme) => ({
@@ -27,6 +27,12 @@ const useStyles = makeStyles((theme) => ({
 
 function EducationTitle(props) {
   const classes = useStyles();
+
+  const duration = () => {
+    const { start, end } = props.duration;
+    return `${parseDateView(start, "year")} - ${parseEndYear(end)}`;
+  };
+
   return (
     <TitleBox id="Education-Title">
       <Box textAlign="left" width="70%">
@@ -44,7 +50,7 @@ function EducationTitle(props) {
       </Box>
       <Box textAlign="right" width="30%">
         <Typography id="duration" className={classes.title}>
-          {parseDateView(props.duration.start, "year")} - {parseDateView(props.duration.end, "year")}
+          {duration()}
         </Typography>
         <Typography id="location" className={classes.subtitle}>
           {props.location}

--- a/src/components/Experience/JobTitle.js
+++ b/src/components/Experience/JobTitle.js
@@ -10,7 +10,7 @@
 
 import { Box, makeStyles, Typography } from "@material-ui/core";
 import React from "react";
-import { parseDateView } from "../../utils/Helpers";
+import { parseDateView, parseEndDate } from "../../utils/Helpers";
 import { TitleBox } from "../common/TitleBox";
 
 const useStyles = makeStyles((theme) => ({
@@ -27,6 +27,11 @@ const useStyles = makeStyles((theme) => ({
 
 function JobTitle(props) {
   const classes = useStyles();
+
+  const duration = () => {
+    const { start, end } = props.duration;
+    return `${parseDateView(start)} - ${parseEndDate(end)}`;
+  };
 
   return (
     <TitleBox id="Job-Title-Box">
@@ -57,7 +62,7 @@ function JobTitle(props) {
           color="primary"
           className={classes.title}
         >
-          {parseDateView(props.duration.start)} - {parseDateView(props.duration.end)}
+          {duration()}
         </Typography>
         <Typography
           id="location"

--- a/src/components/common/CustomDatePicker.js
+++ b/src/components/common/CustomDatePicker.js
@@ -12,6 +12,9 @@ import { DatePicker } from "@material-ui/pickers";
 import React from "react";
 
 const CustomDatePicker = ({ value, label, name, views, onChange, disabled, className }) => {
+  const MIN_DATE = new Date(`${new Date().getFullYear() - 30}-01-01`);
+  const MAX_DATE = new Date(`${new Date().getFullYear()}-12-31`);
+
   return (
     <DatePicker
       variant="inline"
@@ -21,8 +24,8 @@ const CustomDatePicker = ({ value, label, name, views, onChange, disabled, class
       label={label}
       value={value}
       inputVariant="outlined"
-      minDate={new Date("1980-01-01")}
-      maxDate={new Date("2100-01-01")}
+      minDate={MIN_DATE}
+      maxDate={MAX_DATE}
       key={name}
       disabled={disabled}
       onChange={onChange}

--- a/src/utils/Helpers.js
+++ b/src/utils/Helpers.js
@@ -93,17 +93,23 @@ export const parseLines = (value) =>
 
 export const parseDateView = (date, year) => {
   const obj = new Date(date);
-  const currYear = currentDate().split("-")[2];
-  const currMonth = currentDate().split("-")[0];
-  
-  if (
-    currMonth === (obj.getMonth() + 1).toString() &&
-    currYear === obj.getFullYear().toString()
-  )
-    return "Present";
-
-  if (year && obj.getFullYear().toString() === currYear) return "Present";
   if (year) return obj.toLocaleString([], { year: "numeric" });
 
   return obj.toLocaleString([], { month: "short", year: "numeric" });
 };
+
+const sameYear = (date) => {
+  return new Date(date).getFullYear() === new Date().getFullYear();
+};
+
+const sameMonth = (date) => {
+  return new Date(date).getMonth() === new Date().getMonth();
+};
+
+export const parseEndDate = (date) => {
+  return sameYear(date) && sameMonth(date) ? "Present" : parseDateView(date);
+}
+
+export const parseEndYear = (date) => {
+  return sameYear(date) ? "Present" : parseDateView(date, "year");
+}


### PR DESCRIPTION
## Changelog
* Fixed the bug mentioned by @siddarthkarki in #5
> If the start date of the job is Jan 2021, it gets displayed as "Present". So a job I am working at right now which I have started on Jan 2021 gets displayed as "Present-Present"
* Tried to fix invalid dates into the future.
* This closes #26 
