### PR TITLE
Fixed Website Crashing on Skill input

### DIFF
--- a/src/components/Certifications/CertificationTitle.js
+++ b/src/components/Certifications/CertificationTitle.js
@@ -80,7 +80,7 @@ function CertificationTitle({ name, authority, number, duration, link }) {
   const renderIssueDate = () =>
     duration.obtained ? (
       <Fragment>
-        {authority || number ? <VerticalLine />: null}
+        {authority || number ? <VerticalLine /> : null}
         <Typography id="issuedate" className={classes.duration}>
           Issued: {parseDateView(duration.obtained)}
         </Typography>

--- a/src/components/Skills/SkillsInput.js
+++ b/src/components/Skills/SkillsInput.js
@@ -89,7 +89,7 @@ function SkillsInput() {
     const rawValue = e.target.value;
 
     //match the invalid chars
-    if(!rawValue.match(/^[a-zA-Z0-9#_.]/)) return;
+    if (!rawValue.match(/^[a-zA-Z0-9#_.]/)) return;
 
     //Process entry on Enter Key.
     if (rawValue && ["Enter"].includes(e.key)) {
@@ -105,7 +105,7 @@ function SkillsInput() {
         if (response.length !== 0) {
           setState([...state, response[0]]);
           e.target.value = "";
-          addUserSkill(uid, response[0]._id).then(console.log("added"));
+          addUserSkill(uid, response[0]._id);
         } else
           addSkillToDatabase(value, "Miscellaneous").then(() =>
             fetchInDatabase(value).then((newSkill) => {
@@ -114,7 +114,7 @@ function SkillsInput() {
               addUserSkill(uid, newSkill[0]._id);
             })
           );
-      });
+      })
     }
   };
 

--- a/src/components/Skills/skills.actions.js
+++ b/src/components/Skills/skills.actions.js
@@ -58,9 +58,9 @@ export const fetchSkills = (uid) => {
 
 export const fetchInDatabase = async (name) => {
   return axios
-    .get(`${SERVER}/skillset/fetchbyname/${name}`)
+    .post(`${SERVER}/skillset/fetchbyname`, {name})
     .then((response) => response.data)
-    .catch((err) => err.message);
+    .catch((err) => err);
 };
 
 export const createNewSkillDocument = async (uid) => {
@@ -68,7 +68,7 @@ export const createNewSkillDocument = async (uid) => {
     .post(`${SERVER}/skills/add`, { uid })
     .then((response) => response.data)
     .catch((err) => err.message);
-}
+};
 
 export const addUserSkill = async (uid, skillId) => {
   return axios


### PR DESCRIPTION
## Context
The error was caused by faulty requests sent through a `GET` method to fetch skills in the database.
![Screenshot 2021-02-10 174217](https://user-images.githubusercontent.com/30192068/107520352-57cb1600-6bd7-11eb-91a4-c7f229d0b18a.jpg)
This caused special character inputs and escape sequences to crash the system.

## Changelog
* Updated the `fetchbyname` method from `GET` to `POST` to send the data.
* Fixed the empty or undefined response crashing case.
* This closes #39 